### PR TITLE
Fixing exception when IEnumerable is implemented on a base type.

### DIFF
--- a/src/AutoCompare.Tests/BuilderTests.cs
+++ b/src/AutoCompare.Tests/BuilderTests.cs
@@ -54,5 +54,20 @@ namespace AutoCompare.Tests
                 new HasIgnores() { Id = 2, IgnoreValue = 200 });
             Assert.AreEqual(0, diff.Count);
         }
+
+        [TestMethod]
+        public void Compile_A_Type_With_IEnumerable_Parent_Class()
+        {
+            SutEngine.Configure<InheritedIEnumerableModel>()
+                .Compile.Now();
+        }
+
+        [TestMethod]
+        public void Compile_A_Configured_Type_With_IEnumerable_Parent_Class()
+        {
+            SutEngine.Configure<InheritedIEnumerableModel>()
+                .For(x => x.Children, x => x.MatchUsing(y => y.Id))
+                .Compile.Now();
+        }
     }
 }

--- a/src/AutoCompare.Tests/ConfigurationTests.cs
+++ b/src/AutoCompare.Tests/ConfigurationTests.cs
@@ -205,6 +205,56 @@ namespace AutoCompare.Tests
         }
 
         [TestMethod]
+        public void Configure_Inherited_IEnumerable()
+        {
+            SutEngine.Configure<InheritedIEnumerableModel>()
+                .For(x => x.Children, x => x.MatchUsing(y => y.Id));
+
+            var oldModel = new InheritedIEnumerableModel()
+            {
+                Id = 1,
+                Children = new IEnumerableCollectionClass
+                {
+                    new GrandChildModel()
+                    {
+                        Id = 100,
+                        Name = "Name 1",
+                        Value = 100
+                    },
+                    new GrandChildModel()
+                    {
+                        Id = 200,
+                        Name = "Name 2",
+                        Value = 200
+                    }
+                },
+            };
+
+            var newModel = new InheritedIEnumerableModel()
+            {
+                Id = 1,
+                Children = new IEnumerableCollectionClass
+                {
+                    new GrandChildModel()
+                    {
+                        Id = 100,
+                        Name = "Name 1",
+                        Value = 100
+                    },
+                    new GrandChildModel()
+                    {
+                        Id = 300,
+                        Name = "Name 3",
+                        Value = 300
+                    }
+                },
+            };
+
+            var diff = SutEngine.Compare(oldModel, newModel);
+            Assert.AreEqual(6, diff.Count);
+        }
+
+        [TestMethod]
         public void Configure_IDictionary()
         {
             SutEngine.Configure<IDictionaryModel>();

--- a/src/AutoCompare.Tests/TestModels.cs
+++ b/src/AutoCompare.Tests/TestModels.cs
@@ -171,6 +171,17 @@ namespace AutoCompare.Tests
         public IDictionary<int, GrandChildModel> Children { get; set; }
     }
 
+    public class InheritedIEnumerableModel
+    {
+        public int Id { get; set; }
+        public IEnumerableCollectionClass Children {get;set;}
+    }
+
+    public class IEnumerableCollectionClass : List<GrandChildModel>
+    {
+
+    }
+
     public class PublicFieldsModel
     {
         public int Id;


### PR DESCRIPTION
When the IEnumerable<T> of a member is actually specified in the base type of a member, an exception is thrown.  There were no types returned from the call to memberType.GetGenericArguments().  Either the call to .First(), or the Length check within GetCompareIEnumerableMethodInfo would throw an exception during compilation.

The new test model should convey what I am talking about a little clearer.

I added a new private method to handle this case, first trying the simple case of what the old code did, and then trying to find the <T> from whatever descendant actually inherits from IEnumerable<T>.

As a side note, I really like how this library is laid out.  We have a need for something like this on our project in the future and I'm trying to test a few options out.  We have a pretty huge object graph we would like to do comparisons against, so, it should be a pretty good test for edge cases on this library.
