### PR TITLE
Fixed a compilation exception when a member type is a struct

### DIFF
--- a/src/AutoCompare.Tests/BuilderTests.cs
+++ b/src/AutoCompare.Tests/BuilderTests.cs
@@ -69,5 +69,12 @@ namespace AutoCompare.Tests
                 .For(x => x.Children, x => x.MatchUsing(y => y.Id))
                 .Compile.Now();
         }
+
+        [TestMethod]
+        public void Compile_A_Type_With_A_Struct_Member()
+        {
+            SutEngine.Configure<StructModel>()
+                .Compile.Now();
+        }
     }
 }

--- a/src/AutoCompare.Tests/ComparerTests.cs
+++ b/src/AutoCompare.Tests/ComparerTests.cs
@@ -80,5 +80,33 @@ namespace AutoCompare.Tests
             Assert.AreEqual(changes.Count(), 1);
             Assert.IsNotNull(changes.Single(x => x.Name == "Id" && (long)x.OldValue == 1 && (long)x.NewValue == 2));
         }
+
+        [TestMethod]
+        public void Static_Comparer_A_Value_Type()
+        {
+            var oldModel = new StructModel
+            {
+                Id = 1,
+                StructMember = new StructMember
+                {
+                    Id = 1,
+                    Value = "Old"
+                }
+            };
+
+            var newModel = new StructModel
+            {
+                Id = 1,
+                StructMember = new StructMember
+                {
+                    Id = 1,
+                    Value = "New"
+                }
+            };
+
+            var changes = Comparer.Compare(oldModel, newModel);
+            Assert.AreEqual(changes.Count(), 1);
+            Assert.IsNotNull(changes.Single(x => x.Name == "StructMember.Value" && (string)x.OldValue == "Old" && (string)x.NewValue == "New"));
+        }
     }
 }

--- a/src/AutoCompare.Tests/TestModels.cs
+++ b/src/AutoCompare.Tests/TestModels.cs
@@ -177,6 +177,18 @@ namespace AutoCompare.Tests
         public IEnumerableCollectionClass Children {get;set;}
     }
 
+    public class StructModel
+    {
+        public int Id { get; set; }
+        public StructMember StructMember { get; set; }
+    }
+    
+    public struct StructMember
+    {
+        public int Id { get; set; }
+        public string Value { get; set; }
+    }
+
     public class IEnumerableCollectionClass : List<GrandChildModel>
     {
 


### PR DESCRIPTION
When generating the Expression to compare a member, an exception would be thrown if that member is a struct.  Structs don't implement '==' by default, so the compilation exception was thrown due to the null checks in the expression.

`a == null || b == null`

So, I added a check for .IsValueType, and then added a new expression, which is basically the same as the old one for comparing simple types, but with the null checks against the struct removed.

I'm not sure that the IsValueType check really needs pulled out into a separate method.  Mostly, when first writing it, I wasn't sure if there would need to be any other checks done against the type.
